### PR TITLE
Added confirmation to clear scene, and delete object as a menu item

### DIFF
--- a/src/gui/GuiScene.js
+++ b/src/gui/GuiScene.js
@@ -16,7 +16,7 @@ class GuiScene {
     var menu = this._menu = guiParent.addMenu(TR('sceneTitle'));
 
     // scene
-    menu.addButton(TR('sceneReset'), this._main, 'clearScene' /*, 'CTRL+ALT+N'*/ );
+    menu.addButton(TR('sceneReset'), this, 'clearScene' /*, 'CTRL+ALT+N'*/ );
     menu.addButton(TR('sceneAddSphere'), this._main, 'addSphere');
     menu.addButton(TR('sceneAddCube'), this._main, 'addCube');
     menu.addButton(TR('sceneAddCylinder'), this._main, 'addCylinder');
@@ -40,8 +40,9 @@ class GuiScene {
     this._ctrlIsolate.setVisibility(false);
     this._ctrlMerge = menu.addButton(TR('sceneMerge'), this, 'merge');
     this._ctrlMerge.setVisibility(false);
-
+    
     menu.addButton(TR('sceneDuplicate'), this, 'duplicateSelection');
+    menu.addButton(TR('sceneDelete'), this, 'deleteSelection');
 
     // extra
     menu.addTitle(TR('renderingExtra'));
@@ -51,8 +52,18 @@ class GuiScene {
     menu.addCheckbox(TR('renderingSymmetryLine'), ShaderBase.showSymmetryLine, this.onShowSymmetryLine.bind(this));
   }
 
+  clearScene(){
+    if (window.confirm(TR('sceneResetConfirm'))){
+      this._main.clearScene();
+    }
+  }
+
   duplicateSelection() {
     this._main.duplicateSelection();
+  }
+
+  deleteSelection(){
+    this._main.deleteCurrentSelection();
   }
 
   validatePreview() {

--- a/src/gui/tr/chinese.js
+++ b/src/gui/tr/chinese.js
@@ -38,12 +38,14 @@ var TR = {
   // scene
   sceneTitle: '場景',
   sceneReset: '清除場景',
+  sceneResetConfirm: '確認清除場景',
   sceneAddSphere: '加入球體',
   sceneAddCube: '加入立方體',
   sceneAddCylinder: '加入圓柱',
   sceneAddTorus: '加入圓環',
   sceneSelection: '選取項目',
   sceneMerge: '合併選取項目',
+  sceneDuplicate: '刪除選擇',
   sceneDuplicate: null,
 
   // mesh

--- a/src/gui/tr/english.js
+++ b/src/gui/tr/english.js
@@ -38,6 +38,7 @@ var TR = {
   // scene
   sceneTitle: 'Scene',
   sceneReset: 'Clear scene',
+  sceneResetConfirm: 'Confirm clear scene',
   sceneAddSphere: 'Add sphere',
   sceneAddCube: 'Add cube',
   sceneAddCylinder: 'Add cylinder',
@@ -45,6 +46,7 @@ var TR = {
   sceneSelection: 'Selection',
   sceneMerge: 'Merge selection',
   sceneDuplicate: 'Copy selection',
+  sceneDelete: 'Delete selection',
 
   // mesh
   meshTitle: 'Mesh',

--- a/src/gui/tr/french.js
+++ b/src/gui/tr/french.js
@@ -38,6 +38,7 @@ var TR = {
   // scene
   sceneTitle: 'Scène',
   sceneReset: 'Réinitialiser scène',
+  sceneResetConfirm: 'Confirmer réinitialiser la scène?',
   sceneAddSphere: 'Ajouter sphere',
   sceneAddCube: 'Ajouter cube',
   sceneAddCylinder: 'Ajouter cylindre',
@@ -45,6 +46,7 @@ var TR = {
   sceneSelection: 'Sélection',
   sceneMerge: 'Fusionner selection',
   sceneDuplicate: null,
+  sceneDelete: 'Supprimer la sélection',
 
   // mesh
   meshTitle: 'Mesh',

--- a/src/gui/tr/korean.js
+++ b/src/gui/tr/korean.js
@@ -38,6 +38,7 @@ var TR = {
   // scene
   sceneTitle: '장면',
   sceneReset: '모두 없애기',
+  sceneConfirmReset: '모두 제거 확인',
   sceneAddSphere: '구 추가하기',
   sceneAddCube: '정육면체 추가하기',
   sceneAddCylinder: '기둥 추가하기',
@@ -45,6 +46,7 @@ var TR = {
   sceneSelection: '선택',
   sceneMerge: '장면 병합하기',
   sceneDuplicate: null,
+  sceneDelete: '선택 항목 삭제',
 
   // mesh
   meshTitle: '메시',

--- a/src/gui/tr/korean.js
+++ b/src/gui/tr/korean.js
@@ -38,7 +38,7 @@ var TR = {
   // scene
   sceneTitle: '장면',
   sceneReset: '모두 없애기',
-  sceneConfirmReset: '모두 제거 확인',
+  sceneResetConfirm: '모두 제거 확인',
   sceneAddSphere: '구 추가하기',
   sceneAddCube: '정육면체 추가하기',
   sceneAddCylinder: '기둥 추가하기',

--- a/src/gui/tr/russian.js
+++ b/src/gui/tr/russian.js
@@ -38,7 +38,7 @@ var TR = {
   // scene
   sceneTitle: 'Сцена',
   sceneReset: 'Очистить сцену',
-  sceneConfirmReset: 'Подтвердить четкую сцену',
+  sceneResetConfirm: 'Подтвердить четкую сцену',
   sceneAddSphere: 'Добавить сферу',
   sceneAddCube: 'Добавить куб',
   sceneAddCylinder: 'Добавить цилиндр',

--- a/src/gui/tr/russian.js
+++ b/src/gui/tr/russian.js
@@ -38,6 +38,7 @@ var TR = {
   // scene
   sceneTitle: 'Сцена',
   sceneReset: 'Очистить сцену',
+  sceneConfirmReset: 'Подтвердить четкую сцену',
   sceneAddSphere: 'Добавить сферу',
   sceneAddCube: 'Добавить куб',
   sceneAddCylinder: 'Добавить цилиндр',
@@ -45,6 +46,7 @@ var TR = {
   sceneSelection: 'Выбрать',
   sceneMerge: 'Объединить',
   sceneDuplicate: null,
+  sceneDelete: 'Удалить выделение',
 
   // mesh
   meshTitle: 'Сетка',

--- a/src/gui/tr/swedish.js
+++ b/src/gui/tr/swedish.js
@@ -38,6 +38,7 @@ var TR = {
   // scene
   sceneTitle: 'Scen',
   sceneReset: 'Rensa scen',
+  sceneConfirmReset: 'Bekräfta klar scen',
   sceneAddSphere: 'Lägg till sfär',
   sceneAddCube: 'Lägg till kub',
   sceneAddCylinder: 'Lägg till cylinder',
@@ -45,6 +46,7 @@ var TR = {
   sceneSelection: 'Urval',
   sceneMerge: 'Sammanfoga urval',
   sceneDuplicate: null,
+  sceneDelete: 'Radera valet',
 
   // mesh
   meshTitle: 'Mesh',

--- a/src/gui/tr/swedish.js
+++ b/src/gui/tr/swedish.js
@@ -38,7 +38,7 @@ var TR = {
   // scene
   sceneTitle: 'Scen',
   sceneReset: 'Rensa scen',
-  sceneConfirmReset: 'Bekräfta klar scen',
+  sceneResetConfirm: 'Bekräfta klar scen',
   sceneAddSphere: 'Lägg till sfär',
   sceneAddCube: 'Lägg till kub',
   sceneAddCylinder: 'Lägg till cylinder',

--- a/src/gui/tr/turkish.js
+++ b/src/gui/tr/turkish.js
@@ -38,6 +38,7 @@ var TR = {
   // scene
   sceneTitle: 'Sahne',
   sceneReset: 'Sahneyi temizle',
+  sceneConfirmReset: 'Net sahneyi doğrulayın',
   sceneAddSphere: 'Küre ekle',
   sceneAddCube: 'Küp ekle',
   sceneAddCylinder: 'Silindir ekle',
@@ -45,6 +46,7 @@ var TR = {
   sceneSelection: 'Seçim',
   sceneMerge: 'Seçimi birleştir',
   sceneDuplicate: null,
+  sceneDelete: 'Seçimi sil',
 
   // mesh
   meshTitle: 'Nesne',

--- a/src/gui/tr/turkish.js
+++ b/src/gui/tr/turkish.js
@@ -38,7 +38,7 @@ var TR = {
   // scene
   sceneTitle: 'Sahne',
   sceneReset: 'Sahneyi temizle',
-  sceneConfirmReset: 'Net sahneyi doğrulayın',
+  sceneResetConfirm: 'Net sahneyi doğrulayın',
   sceneAddSphere: 'Küre ekle',
   sceneAddCube: 'Küp ekle',
   sceneAddCylinder: 'Silindir ekle',


### PR DESCRIPTION
So the a few times now the lack of confirmation on the 'Clear Scene' menu item has bitten me when I went to add a new object and clicked instead loosing my work, so I added a basic confirmation dialog to 'Clear scene'. 

I also noticed while using Sculptgl on a tablet without a keyboard there is no way to access 'delete object' without a keyboard. 